### PR TITLE
Implement Batch Mode for multi-wallet exports

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,8 +1,8 @@
 import argparse
+import csv
 import logging
 import os
 import sys
-from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import datetime
 from typing import Dict, List, Optional, Type
 
@@ -57,6 +57,12 @@ class Args(BaseModel):
             raise ValueError("Incorrect date format, should be YYYY-MM-DD")
         return v
 
+    @model_validator(mode='after')
+    def check_at_least_one_address_source(self):
+        if not self.wallet and not self.address_file and not os.getenv('WALLET_ADDRESS') and not os.getenv('WALLET_ADDRESSES'):
+            raise ValueError("No wallet addresses provided. Use --wallet, --address-file, or set WALLET_ADDRESS/WALLET_ADDRESSES in your .env file.")
+        return self
+
 def combine_and_sort_transactions(
     transactions: List[Transaction],
     token_transfers: List[Transaction],
@@ -71,6 +77,39 @@ def combine_and_sort_transactions(
     )
 
     return all_transactions_sorted
+
+
+def get_addresses_from_file(file_path: str) -> List[str]:
+    """
+    Reads wallet addresses from a TXT or CSV file.
+    """
+    addresses = []
+    try:
+        with open(file_path, 'r', newline='') as f:
+            if file_path.endswith('.csv'):
+                reader = csv.reader(f)
+                for row in reader:
+                    for cell in row:
+                        clean_cell = cell.strip()
+                        # Simple EVM address check: starts with 0x and length 42
+                        if clean_cell.startswith('0x') and len(clean_cell) == 42:
+                            addresses.append(clean_cell)
+            else:
+                # Treat as TXT, one address per line
+                for line in f:
+                    clean_line = line.strip()
+                    if clean_line.startswith('0x') and len(clean_line) == 42:
+                        addresses.append(clean_line)
+                    elif clean_line:
+                        # Fallback for lines that might not be perfectly formatted
+                        # but could contain an address
+                        parts = clean_line.split()
+                        for part in parts:
+                            if part.startswith('0x') and len(part) == 42:
+                                addresses.append(part)
+    except Exception as e:
+        logging.error(f"Error reading address file {file_path}: {e}")
+    return addresses
 
 
 def process_transactions(
@@ -127,6 +166,50 @@ def process_transactions(
     return all_sorted_transactions
 
 
+def process_batch_transactions(
+    addresses: List[str],
+    chain: str,
+    output_format: str,
+    start_date: Optional[str] = None,
+    end_date: Optional[str] = None
+) -> None:
+    """
+    Processes multiple wallet addresses sequentially.
+    """
+    for i, wallet_address in enumerate(addresses):
+        try:
+            all_sorted_transactions = process_transactions(
+                wallet_address,
+                chain,
+                start_date,
+                end_date
+            )
+
+            # Convert Pydantic models to dictionaries for writers
+            output_data = [trx.model_dump(by_alias=True) for trx in all_sorted_transactions]
+
+            # Define the output path based on the format
+            output_file = f'output/{wallet_address}_transactions.{output_format}'
+
+            # Write the data to the selected format
+            if output_format == 'csv':
+                write_transaction_data_to_csv(output_file, output_data)
+            elif output_format == 'json':
+                write_transaction_data_to_json(output_file, output_data)
+            elif output_format == 'cointracker':
+                write_transaction_data_to_cointracker_csv(output_file, output_data)
+            elif output_format == 'cryptotaxcalculator':
+                write_transaction_data_to_cryptotaxcalculator_csv(output_file, output_data)
+            elif output_format == 'koinly':
+                write_transaction_data_to_koinly_csv(output_file, output_data)
+
+            logging.info(f"({i + 1}/{len(addresses)}) "
+                         f"Successfully wrote {len(output_data)} transactions to {output_file} for wallet {wallet_address}")
+
+        except Exception as e:
+            logging.error(f"Failed to process address {wallet_address}: {e}")
+
+
 # Main function
 def main() -> None:
     # Set up argument parser
@@ -154,24 +237,20 @@ def main() -> None:
     # Collect wallet addresses from all sources
     wallet_addresses = []
     if validated_args.wallet:
-        wallet_addresses.extend(validated_args.wallet.split(','))
+        wallet_addresses.extend([addr.strip() for addr in validated_args.wallet.split(',') if addr.strip()])
     if validated_args.address_file:
-        try:
-            with open(validated_args.address_file, 'r') as f:
-                wallet_addresses.extend([line.strip() for line in f if line.strip()])
-        except FileNotFoundError:
-            logging.error(f"Address file not found: {validated_args.address_file}")
+        wallet_addresses.extend(get_addresses_from_file(validated_args.address_file))
 
     # Fallback to environment variables if no addresses are provided via arguments
     if not wallet_addresses:
         env_addresses = os.getenv('WALLET_ADDRESSES')
         if env_addresses:
-            wallet_addresses.extend(env_addresses.split(','))
+            wallet_addresses.extend([addr.strip() for addr in env_addresses.split(',') if addr.strip()])
         elif os.getenv('WALLET_ADDRESS'):
-            wallet_addresses.append(os.getenv('WALLET_ADDRESS'))
+            wallet_addresses.append(os.getenv('WALLET_ADDRESS').strip())
 
-    # Ensure there are unique addresses to process
-    unique_addresses = sorted(list(set(addr.strip() for addr in wallet_addresses if addr.strip())))
+    # Ensure there are unique addresses to process (lowercased for deduplication)
+    unique_addresses = sorted(list(set(addr.lower() for addr in wallet_addresses if addr)))
 
     if not unique_addresses:
         logging.error(
@@ -180,46 +259,14 @@ def main() -> None:
         )
         return
 
-    # Process each wallet address
-    with ThreadPoolExecutor(max_workers=5) as executor:
-        future_to_address = {
-            executor.submit(
-                process_transactions,
-                address,
-                validated_args.chain,
-                validated_args.start_date,
-                validated_args.end_date
-            ): address for address in unique_addresses
-        }
-
-        for i, future in enumerate(as_completed(future_to_address)):
-            wallet_address = future_to_address[future]
-            try:
-                all_sorted_transactions = future.result()
-
-                # Convert Pydantic models to dictionaries for writers
-                output_data = [trx.model_dump(by_alias=True) for trx in all_sorted_transactions]
-
-                # Define the output path based on the format
-                output_file = f'output/{wallet_address}_transactions.{validated_args.format}'
-
-                # Write the data to the selected format
-                if validated_args.format == 'csv':
-                    write_transaction_data_to_csv(output_file, output_data)
-                elif validated_args.format == 'json':
-                    write_transaction_data_to_json(output_file, output_data)
-                elif validated_args.format == 'cointracker':
-                    write_transaction_data_to_cointracker_csv(output_file, output_data)
-                elif validated_args.format == 'cryptotaxcalculator':
-                    write_transaction_data_to_cryptotaxcalculator_csv(output_file, output_data)
-                elif validated_args.format == 'koinly':
-                    write_transaction_data_to_koinly_csv(output_file, output_data)
-
-                logging.info(f"({i + 1}/{len(unique_addresses)}) "
-                             f"Successfully wrote {len(output_data)} transactions to {output_file} for wallet {wallet_address}")
-
-            except Exception as e:
-                logging.error(f"Failed to process address {wallet_address}: {e}")
+    # Process all wallet addresses in batch (sequentially)
+    process_batch_transactions(
+        unique_addresses,
+        validated_args.chain,
+        validated_args.format,
+        validated_args.start_date,
+        validated_args.end_date
+    )
 
 if __name__ == "__main__":
     main()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -124,7 +124,8 @@ def test_main_csv_output_with_wallet_arg(
     mock_getenv, mock_write_csv, mock_process, mock_argparse
 ):
     mock_args = MagicMock()
-    mock_args.wallet = "0x123"
+    addr = "0x" + "a" * 40
+    mock_args.wallet = addr
     mock_args.start_date = None
     mock_args.end_date = None
     mock_args.format = "csv"
@@ -138,9 +139,9 @@ def test_main_csv_output_with_wallet_arg(
 
     main()
 
-    mock_process.assert_called_with("0x123", CHAIN, None, None)
+    mock_process.assert_called_with(addr, CHAIN, None, None)
     mock_write_csv.assert_called_with(
-        "output/0x123_transactions.csv",
+        f"output/{addr}_transactions.csv",
         [
             {
                 "Date": "1",
@@ -166,7 +167,8 @@ def test_main_csv_output_with_wallet_arg(
 @patch("main.write_transaction_data_to_json")
 def test_main_json_output(mock_write_json, mock_process, mock_argparse):
     mock_args = MagicMock()
-    mock_args.wallet = "0x123"
+    addr = "0x" + "b" * 40
+    mock_args.wallet = addr
     mock_args.start_date = None
     mock_args.end_date = None
     mock_args.format = "json"
@@ -180,9 +182,9 @@ def test_main_json_output(mock_write_json, mock_process, mock_argparse):
 
     main()
 
-    mock_process.assert_called_with("0x123", CHAIN, None, None)
+    mock_process.assert_called_with(addr, CHAIN, None, None)
     mock_write_json.assert_called_with(
-        "output/0x123_transactions.json",
+        f"output/{addr}_transactions.json",
         [
             {
                 "Date": "1",
@@ -207,7 +209,8 @@ def test_main_json_output(mock_write_json, mock_process, mock_argparse):
 @patch("main.write_transaction_data_to_csv")
 def test_main_csv_output(mock_write_csv, mock_process, mock_argparse):
     mock_args = MagicMock()
-    mock_args.wallet = "0x123"
+    addr = "0x" + "c" * 40
+    mock_args.wallet = addr
     mock_args.start_date = None
     mock_args.end_date = None
     mock_args.format = "csv"
@@ -221,9 +224,9 @@ def test_main_csv_output(mock_write_csv, mock_process, mock_argparse):
 
     main()
 
-    mock_process.assert_called_with("0x123", CHAIN, None, None)
+    mock_process.assert_called_with(addr, CHAIN, None, None)
     mock_write_csv.assert_called_with(
-        "output/0x123_transactions.csv",
+        f"output/{addr}_transactions.csv",
         [
             {
                 "Date": "1",


### PR DESCRIPTION
This PR implements the "Batch Mode" feature for multi-wallet exports. 

Key changes:
- **Sequential Processing:** Replaced `ThreadPoolExecutor` with a sequential loop in `process_batch_transactions` to better respect API rate limits and provide clearer logs for accountants processing many wallets.
- **Robust File Parsing:** Added `get_addresses_from_file` which uses the `csv` module to parse CSVs and also supports TXT files. It extracts valid Ethereum addresses (0x... length 42) from any column/line, ignoring headers or extra data.
- **Address Normalization:** All addresses are now lowercased during collection to ensure unique processing.
- **Improved Validation:** Added a Pydantic `model_validator` to `Args` to verify that at least one address source (CLI arg or environment variable) is present.
- **Test Suite Updates:** Updated `tests/test_batch_processing.py` and `tests/test_main.py` to use valid 42-character addresses. Fixed a fundamentally broken `tests/test_end_to_end.py` by switching from `subprocess.run` to direct `main()` calls, enabling effective network mocking.
- **Environment Fixes:** Explicitly installed `setuptools` to fix `distutils` errors on Python 3.12.

All 74 tests pass, and linting is clean.

Fixes #103

---
*PR created automatically by Jules for task [5202169445576989025](https://jules.google.com/task/5202169445576989025) started by @username-anthony-is-not-available*