### PR TITLE
Map MintChain Token Transfers to Koinly Labeling

### DIFF
--- a/koinly_writer.py
+++ b/koinly_writer.py
@@ -9,15 +9,29 @@ KOINLY_LABEL_MAP = {
     TransactionType.MINING.value: "mining",
 }
 
-def write_transaction_data_to_koinly_csv(output_file: str, transaction_data: List[Dict[str, Union[str, None]]]) -> None:
+MINTCHAIN_LABEL_MAP = {
+    TransactionType.TRANSFER.value: "",
+    TransactionType.TOKEN_TRANSFER.value: "",
+}
+
+
+def write_transaction_data_to_koinly_csv(
+    output_file: str,
+    transaction_data: List[Dict[str, Union[str, None]]],
+    chain: str = 'mintchain'
+) -> None:
     os.makedirs(os.path.dirname(output_file), exist_ok=True)
 
     processed_transactions = []
     for tx in transaction_data:
         processed_tx = tx.copy()
         label = processed_tx.get("Label")
-        if label and label in KOINLY_LABEL_MAP:
+
+        if chain == 'mintchain' and label in MINTCHAIN_LABEL_MAP:
+            processed_tx["Label"] = MINTCHAIN_LABEL_MAP[label]
+        elif label and label in KOINLY_LABEL_MAP:
             processed_tx["Label"] = KOINLY_LABEL_MAP[label]
+
         processed_transactions.append(processed_tx)
 
     fieldnames: List[str] = [

--- a/main.py
+++ b/main.py
@@ -201,7 +201,7 @@ def process_batch_transactions(
             elif output_format == 'cryptotaxcalculator':
                 write_transaction_data_to_cryptotaxcalculator_csv(output_file, output_data)
             elif output_format == 'koinly':
-                write_transaction_data_to_koinly_csv(output_file, output_data)
+                write_transaction_data_to_koinly_csv(output_file, output_data, chain=chain)
 
             logging.info(f"({i + 1}/{len(addresses)}) "
                          f"Successfully wrote {len(output_data)} transactions to {output_file} for wallet {wallet_address}")

--- a/tests/test_koinly_writer.py
+++ b/tests/test_koinly_writer.py
@@ -4,8 +4,8 @@ from unittest.mock import MagicMock, patch
 from koinly_writer import write_transaction_data_to_koinly_csv
 
 @patch('os.makedirs')
-def test_write_transaction_data_to_koinly_csv(mock_makedirs: MagicMock) -> None:
-    output_file = 'output/koinly_transactions.csv'
+def test_write_transaction_data_to_koinly_csv_mintchain(mock_makedirs: MagicMock) -> None:
+    output_file = 'output/koinly_transactions_mintchain.csv'
     transaction_data = [
         {
             'Date': '1672531200',
@@ -17,16 +17,93 @@ def test_write_transaction_data_to_koinly_csv(mock_makedirs: MagicMock) -> None:
             'Fee Currency': 'ETH',
             'Net Worth Amount': '',
             'Net Worth Currency': '',
-            'Label': 'cost',
+            'Label': 'transfer',
             'Description': 'transaction',
-            'TxHash': '0x1234567890abcdef'
+            'TxHash': '0x123'
+        },
+        {
+            'Date': '1672531201',
+            'Sent Amount': '100',
+            'Sent Currency': 'TKN',
+            'Received Amount': '',
+            'Received Currency': '',
+            'Fee Amount': '0.001',
+            'Fee Currency': 'ETH',
+            'Net Worth Amount': '',
+            'Net Worth Currency': '',
+            'Label': 'token_transfer',
+            'Description': 'token_transfer',
+            'TxHash': '0x456'
+        },
+        {
+            'Date': '1672531202',
+            'Sent Amount': '',
+            'Sent Currency': '',
+            'Received Amount': '1',
+            'Received Currency': 'ETH',
+            'Fee Amount': '0',
+            'Fee Currency': 'ETH',
+            'Net Worth Amount': '',
+            'Net Worth Currency': '',
+            'Label': 'staking',
+            'Description': 'transaction',
+            'TxHash': '0x789'
         }
     ]
 
+    expected_processed_data = [
+        {**transaction_data[0], 'Label': ''},
+        {**transaction_data[1], 'Label': ''},
+        {**transaction_data[2], 'Label': 'staking'},
+    ]
+
     with patch('builtins.open', new_callable=MagicMock) as mock_open:
-        write_transaction_data_to_koinly_csv(output_file, transaction_data)
+        write_transaction_data_to_koinly_csv(output_file, transaction_data, chain='mintchain')
 
         mock_makedirs.assert_called_once_with(os.path.dirname(output_file), exist_ok=True)
+        mock_open.assert_called_once_with(output_file, 'w', newline='', encoding='utf-8')
+
+        mock_file = mock_open.return_value.__enter__.return_value
+        writer = csv.DictWriter(
+            mock_file,
+            fieldnames=[
+                'Date', 'Sent Amount', 'Sent Currency', 'Received Amount',
+                'Received Currency', 'Fee Amount', 'Fee Currency',
+                'Net Worth Amount', 'Net Worth Currency', 'Label',
+                'Description', 'TxHash'
+            ]
+        )
+        writer.writeheader()
+        writer.writerows(expected_processed_data)
+
+
+@patch('os.makedirs')
+def test_write_transaction_data_to_koinly_csv_etherscan(mock_makedirs: MagicMock) -> None:
+    output_file = 'output/koinly_transactions_etherscan.csv'
+    transaction_data = [
+        {
+            'Date': '1672531200',
+            'Sent Amount': '1',
+            'Sent Currency': 'ETH',
+            'Received Amount': '',
+            'Received Currency': '',
+            'Fee Amount': '0.001',
+            'Fee Currency': 'ETH',
+            'Net Worth Amount': '',
+            'Net Worth Currency': '',
+            'Label': 'transfer',
+            'Description': 'transaction',
+            'TxHash': '0x123'
+        }
+    ]
+
+    # For etherscan, 'transfer' should remain 'transfer' as it's not in KOINLY_LABEL_MAP
+    expected_processed_data = [
+        {**transaction_data[0], 'Label': 'transfer'},
+    ]
+
+    with patch('builtins.open', new_callable=MagicMock) as mock_open:
+        write_transaction_data_to_koinly_csv(output_file, transaction_data, chain='etherscan')
 
         mock_open.assert_called_once_with(output_file, 'w', newline='', encoding='utf-8')
 
@@ -41,4 +118,4 @@ def test_write_transaction_data_to_koinly_csv(mock_makedirs: MagicMock) -> None:
             ]
         )
         writer.writeheader()
-        writer.writerows(transaction_data)
+        writer.writerows(expected_processed_data)


### PR DESCRIPTION
This change implements the mapping of MintChain token transfers to Koinly-compatible labels. It introduces a chain-specific mapping in the Koinly writer that clears the 'Label' field for 'transfer' and 'token_transfer' transaction types when the chain is MintChain. This enables Koinly's automatic categorization engine to correctly identify these transactions as 'Trade' or 'Sent' based on the transaction data.

Key changes:
- `main.py`: Updated to pass the `chain` argument to the Koinly writer.
- `koinly_writer.py`: Added `MINTCHAIN_LABEL_MAP` and updated the writing logic to handle chain-specific mappings.
- `tests/test_koinly_writer.py`: Added new test cases to verify the MintChain-specific behavior and ensure no regressions for other chains.

Fixes #133

---
*PR created automatically by Jules for task [8995336073023977968](https://jules.google.com/task/8995336073023977968) started by @username-anthony-is-not-available*