### PR TITLE
Implement MintChain Bridge Detection

### DIFF
--- a/tests/test_transaction_categorization.py
+++ b/tests/test_transaction_categorization.py
@@ -135,8 +135,29 @@ def test_categorize_with_unknown_address():
     transaction = create_mock_raw_transaction("0xunknown")
     assert categorize_transaction(transaction, "mintchain") == "transfer"
 
-def test_categorize_as_bridge():
-    """Test that a transaction to a bridge contract is categorized as a bridge."""
+def test_categorize_as_bridge_l1():
+    """Test that a transaction to an L1 bridge contract is categorized as a bridge on etherscan."""
     bridge_address = "0x2b3f201543adf73160ba42e1a5b7750024f30420"
     transaction = create_mock_raw_transaction(bridge_address)
+    assert categorize_transaction(transaction, "etherscan") == "bridge"
+
+def test_categorize_as_bridge_l2():
+    """Test that a transaction to an L2 bridge contract is categorized as a bridge on mintchain."""
+    bridge_address = "0x4200000000000000000000000000000000000010"
+    transaction = create_mock_raw_transaction(bridge_address)
+    assert categorize_transaction(transaction, "mintchain") == "bridge"
+
+def test_categorize_as_bridge_incoming():
+    """Test that a transaction from a bridge contract is categorized as a bridge."""
+    bridge_address = "0x4200000000000000000000000000000000000010"
+    raw_trx_data = {
+        "hash": "0xbridge_incoming",
+        "timeStamp": "1672531200",
+        "from": {"hash": bridge_address},
+        "to": {"hash": "0xuser"},
+        "value": "1000000000000000000",
+        "gasUsed": "21000",
+        "gasPrice": "50000000000",
+    }
+    transaction = RawTransaction.model_validate(raw_trx_data)
     assert categorize_transaction(transaction, "mintchain") == "bridge"

--- a/transaction_categorization.py
+++ b/transaction_categorization.py
@@ -22,9 +22,13 @@ DEFI_ROUTERS = {
 }
 
 BRIDGE_CONTRACTS = {
+    "etherscan": {
+        "0x2b3f201543adf73160ba42e1a5b7750024f30420",  # MintChain L1StandardBridge
+        "0xc2c908f3226d9082130d8e48378cd2efb08b521d",  # MintChain L1ERC721Bridge
+    },
     "mintchain": {
-        "0x2b3f201543adf73160ba42e1a5b7750024f30420",  # L1StandardBridge
-        "0xc2c908f3226d9082130d8e48378cd2efb08b521d",  # L1ERC721Bridge
+        "0x4200000000000000000000000000000000000010",  # L2StandardBridge
+        "0x4200000000000000000000000000000000000014",  # L2ERC721Bridge
     }
 }
 
@@ -50,8 +54,7 @@ def categorize_transaction(transaction: AnyRawTransaction, chain: str = 'mintcha
 
     if to_address in chain_routers:
         return TransactionType.SWAP.value
-    
-    if to_address in chain_bridge_contracts:
+    if to_address in chain_bridge_contracts or from_address in chain_bridge_contracts:
         return TransactionType.BRIDGE.value
 
     # Placeholder for staking detection


### PR DESCRIPTION
This PR implements 'Bridge' transaction detection for MintChain. It organizes bridge contract addresses by chain (Ethereum L1 vs MintChain L2) and updates the categorization logic to identify interactions with these contracts as 'bridge' transactions. This ensures that users bridging assets between Ethereum and MintChain have their transactions correctly labeled for tax reporting purposes.

Fixes #102

---
*PR created automatically by Jules for task [8229759593510083134](https://jules.google.com/task/8229759593510083134) started by @username-anthony-is-not-available*