### PR TITLE
Improve Bridge Categorization for MintChain

### DIFF
--- a/koinly_writer.py
+++ b/koinly_writer.py
@@ -7,6 +7,7 @@ KOINLY_LABEL_MAP = {
     TransactionType.STAKING.value: "staking",
     TransactionType.AIRDROP.value: "airdrop",
     TransactionType.MINING.value: "mining",
+    TransactionType.BRIDGE.value: "Bridge",
 }
 
 MINTCHAIN_LABEL_MAP = {

--- a/tests/test_koinly_writer.py
+++ b/tests/test_koinly_writer.py
@@ -48,6 +48,20 @@ def test_write_transaction_data_to_koinly_csv_mintchain(mock_makedirs: MagicMock
             'Label': 'staking',
             'Description': 'transaction',
             'TxHash': '0x789'
+        },
+        {
+            'Date': '1672531203',
+            'Sent Amount': '1',
+            'Sent Currency': 'ETH',
+            'Received Amount': '',
+            'Received Currency': '',
+            'Fee Amount': '0.001',
+            'Fee Currency': 'ETH',
+            'Net Worth Amount': '',
+            'Net Worth Currency': '',
+            'Label': 'bridge',
+            'Description': 'transaction',
+            'TxHash': '0xabc'
         }
     ]
 
@@ -55,6 +69,7 @@ def test_write_transaction_data_to_koinly_csv_mintchain(mock_makedirs: MagicMock
         {**transaction_data[0], 'Label': ''},
         {**transaction_data[1], 'Label': ''},
         {**transaction_data[2], 'Label': 'staking'},
+        {**transaction_data[3], 'Label': 'Bridge'},
     ]
 
     with patch('builtins.open', new_callable=MagicMock) as mock_open:

--- a/tests/test_transaction_categorization.py
+++ b/tests/test_transaction_categorization.py
@@ -147,6 +147,18 @@ def test_categorize_as_bridge_l2():
     transaction = create_mock_raw_transaction(bridge_address)
     assert categorize_transaction(transaction, "mintchain") == "bridge"
 
+def test_categorize_as_bridge_messenger_l1():
+    """Test that a transaction to L1CrossDomainMessenger is categorized as a bridge on etherscan."""
+    bridge_address = "0x194589998064f25ff15a3677a003d14f67a3ae8b"
+    transaction = create_mock_raw_transaction(bridge_address)
+    assert categorize_transaction(transaction, "etherscan") == "bridge"
+
+def test_categorize_as_bridge_messenger_l2():
+    """Test that a transaction to L2CrossDomainMessenger is categorized as a bridge on mintchain."""
+    bridge_address = "0x4200000000000000000000000000000000000007"
+    transaction = create_mock_raw_transaction(bridge_address)
+    assert categorize_transaction(transaction, "mintchain") == "bridge"
+
 def test_categorize_as_bridge_incoming():
     """Test that a transaction from a bridge contract is categorized as a bridge."""
     bridge_address = "0x4200000000000000000000000000000000000010"

--- a/transaction_categorization.py
+++ b/transaction_categorization.py
@@ -25,10 +25,14 @@ BRIDGE_CONTRACTS = {
     "etherscan": {
         "0x2b3f201543adf73160ba42e1a5b7750024f30420",  # MintChain L1StandardBridge
         "0xc2c908f3226d9082130d8e48378cd2efb08b521d",  # MintChain L1ERC721Bridge
+        "0x8922883499e90956e3d237194d7423d9e0b08006",  # OptimismPortal
+        "0x194589998064f25ff15a3677a003d14f67a3ae8b",  # L1CrossDomainMessenger
     },
     "mintchain": {
         "0x4200000000000000000000000000000000000010",  # L2StandardBridge
         "0x4200000000000000000000000000000000000014",  # L2ERC721Bridge
+        "0x4200000000000000000000000000000000000007",  # L2CrossDomainMessenger
+        "0x4200000000000000000000000000000000000016",  # L2ToL1MessagePasser
     }
 }
 


### PR DESCRIPTION
Improved MintChain bridge transaction detection by adding portal and messenger contract addresses to the categorization logic. Also updated the Koinly CSV writer to use the user-requested "Bridge" label for these transactions. Unit tests were added to ensure correctness.

Fixes #132

---
*PR created automatically by Jules for task [7194270097057112702](https://jules.google.com/task/7194270097057112702) started by @username-anthony-is-not-available*