### PR TITLE
Add Token Swap detection via transfer correlation

### DIFF
--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ from cointracker_writer import write_transaction_data_to_cointracker_csv
 from cryptotaxcalculator_writer import write_transaction_data_to_cryptotaxcalculator_csv
 from csv_writer import write_transaction_data_to_csv
 from extract_transaction_data import extract_transaction_data
+from transaction_categorization import detect_swap_from_transfers
 from explorer_adapters import (
     ArbiscanAdapter,
     BasescanAdapter,
@@ -209,8 +210,27 @@ def merge_transactions_by_hash(transactions: List[Transaction]) -> List[Transact
             # If couldn't merge with any existing, add as a new transaction for this hash
             tx_hash_to_merged[tx_hash].append(tx.model_copy())
 
-    # Flatten the map back into a list
+    # Flatten the map back into a list and apply swap detection heuristic
     for tx_list in tx_hash_to_merged.values():
+        # Heuristically detect swaps based on the presence of both sent and received assets
+        swap_label = detect_swap_from_transfers(tx_list)
+
+        for merged_tx in tx_list:
+            # If the transaction is already marked with a high-priority label, keep it.
+            # Otherwise, apply the swap label if detected.
+            current_label = merged_tx.label
+            if (
+                current_label
+                not in [
+                    TransactionType.BRIDGE.value,
+                    TransactionType.STAKING.value,
+                    TransactionType.MINT.value,
+                    TransactionType.BURN.value,
+                    TransactionType.SWAP.value,
+                ]
+                and swap_label
+            ):
+                merged_tx.label = swap_label
         merged_list.extend(tx_list)
 
     return merged_list

--- a/tests/test_transaction_categorization.py
+++ b/tests/test_transaction_categorization.py
@@ -1,6 +1,6 @@
 import pytest
-from models import Address, RawTokenTransfer, RawTransaction, Token, Total
-from transaction_categorization import categorize_transaction
+from models import Address, RawTokenTransfer, RawTransaction, Token, Total, Transaction
+from transaction_categorization import categorize_transaction, detect_swap_from_transfers
 
 # Mock data for testing
 def create_mock_raw_transaction(to_address: str) -> RawTransaction:
@@ -203,3 +203,49 @@ def test_categorize_as_staking_mintchain():
     }
     transaction = RawTransaction.model_validate(raw_trx_data)
     assert categorize_transaction(transaction, "mintchain") == "staking"
+
+def test_detect_swap_from_transfers_no_swap():
+    """Test that detect_swap_from_transfers returns empty for non-swap transactions."""
+    tx1 = Transaction.model_validate({
+        "Date": "2023-01-01 00:00:00 UTC",
+        "timestamp": 1672531200,
+        "Sent Amount": "1.0",
+        "Sent Currency": "ETH",
+        "Description": "transfer",
+        "TxHash": "0x123"
+    })
+    assert detect_swap_from_transfers([tx1]) == ""
+
+def test_detect_swap_from_transfers_swap():
+    """Test that detect_swap_from_transfers returns 'swap' for swap transactions."""
+    tx1 = Transaction.model_validate({
+        "Date": "2023-01-01 00:00:00 UTC",
+        "timestamp": 1672531200,
+        "Sent Amount": "1.0",
+        "Sent Currency": "ETH",
+        "Description": "transfer",
+        "TxHash": "0x123"
+    })
+    tx2 = Transaction.model_validate({
+        "Date": "2023-01-01 00:00:00 UTC",
+        "timestamp": 1672531200,
+        "Received Amount": "100.0",
+        "Received Currency": "USDC",
+        "Description": "token_transfer",
+        "TxHash": "0x123"
+    })
+    assert detect_swap_from_transfers([tx1, tx2]) == "swap"
+
+def test_detect_swap_from_transfers_partial_swap():
+    """Test that detect_swap_from_transfers returns 'swap' for swap transactions where one tx has both."""
+    tx1 = Transaction.model_validate({
+        "Date": "2023-01-01 00:00:00 UTC",
+        "timestamp": 1672531200,
+        "Sent Amount": "1.0",
+        "Sent Currency": "ETH",
+        "Received Amount": "100.0",
+        "Received Currency": "USDC",
+        "Description": "merged_swap",
+        "TxHash": "0x123"
+    })
+    assert detect_swap_from_transfers([tx1]) == "swap"

--- a/transaction_categorization.py
+++ b/transaction_categorization.py
@@ -1,4 +1,5 @@
-from typing import Union
+from decimal import Decimal
+from typing import List, Union
 from models import Raw1155Transfer, RawNFTTransfer, RawTokenTransfer, RawTransaction, TransactionType
 
 # A sample list of DeFi router addresses, organized by chain
@@ -94,3 +95,28 @@ def categorize_transaction(transaction: AnyRawTransaction, chain: str = 'mintcha
         return TransactionType.TRANSFER.value
 
     return "" # Default for simple transfers, deposits, withdrawals.
+
+
+def detect_swap_from_transfers(transactions: List) -> str:
+    """
+    Heuristic to detect a swap based on the presence of both sent and received assets
+    within a single transaction hash.
+    """
+    sent_assets = False
+    received_assets = False
+
+    for tx in transactions:
+        # Check if it has a sent amount
+        sent_amount = getattr(tx, 'sent_amount', None)
+        if sent_amount and Decimal(str(sent_amount)) > 0:
+            sent_assets = True
+
+        # Check if it has a received amount
+        received_amount = getattr(tx, 'received_amount', None)
+        if received_amount and Decimal(str(received_amount)) > 0:
+            received_assets = True
+
+    if sent_assets and received_assets:
+        return TransactionType.SWAP.value
+
+    return ""


### PR DESCRIPTION
This change adds a heuristic-based swap detection to the MintChain transaction processor. It works by inspecting all transfers within a single transaction hash; if it finds both a sent and a received asset, it labels the transaction as a 'swap'. This allows for correct trade pairing in tax software like Koinly or CryptoTaxCalculator even when the DEX router address is not explicitly known. The implementation is integrated into the transaction merging logic and includes safeguards to avoid overwriting more specific labels like 'bridge' or 'staking'.

Fixes #104

---
*PR created automatically by Jules for task [11465783405444312293](https://jules.google.com/task/11465783405444312293) started by @username-anthony-is-not-available*