### PR TITLE
feat: add automatic token price fetching via Coingecko API

### DIFF
--- a/config.py
+++ b/config.py
@@ -27,5 +27,17 @@ NATIVE_CURRENCIES = {
     'polygon': 'MATIC',
 }
 
+# Coingecko configuration
+COINGECKO_BASE_URL = "https://api.coingecko.com/api/v3"
+COINGECKO_PLATFORM_MAP = {
+    'ethereum': 'ethereum',
+    'etherscan': 'ethereum',
+    'polygon': 'polygon-pos',
+    'basescan': 'base',
+    'arbiscan': 'arbitrum-one',
+    'optimism': 'optimistic-ethereum',
+    'mintchain': 'mint-blockchain',  # Placeholder if not officially supported yet
+}
+
 # Timeout value (in seconds)
 TIMEOUT: int = 10

--- a/extract_transaction_data.py
+++ b/extract_transaction_data.py
@@ -10,6 +10,7 @@ from models import (
     Transaction,
 )
 from transaction_categorization import categorize_transaction
+from price_service import get_token_price
 
 AnyRawTransaction = Union[
     RawTransaction, RawTokenTransfer, RawNFTTransfer, Raw1155Transfer
@@ -107,6 +108,33 @@ def extract_transaction_data(
             if is_receiver:
                 data["Received Amount"] = trx.tokenValue
                 data["Received Currency"] = trx.tokenSymbol
+
+        # Fetch and calculate net worth
+        price = None
+        amount_to_value = None
+        currency_to_value = None
+
+        if data["Sent Amount"] and data["Sent Currency"]:
+            amount_to_value = data["Sent Amount"]
+            currency_to_value = data["Sent Currency"]
+            contract_address = trx.contractAddress if isinstance(trx, RawTokenTransfer) else None
+            price = get_token_price(chain, data["timestamp"], contract_address, currency_to_value)
+        elif data["Received Amount"] and data["Received Currency"]:
+            amount_to_value = data["Received Amount"]
+            currency_to_value = data["Received Currency"]
+            contract_address = trx.contractAddress if isinstance(trx, RawTokenTransfer) else None
+            price = get_token_price(chain, data["timestamp"], contract_address, currency_to_value)
+
+        if price is not None and amount_to_value:
+            try:
+                net_worth = Decimal(amount_to_value) * price
+                formatted_net_worth = format(net_worth, "f")
+                if "." in formatted_net_worth:
+                    formatted_net_worth = formatted_net_worth.rstrip("0").rstrip(".")
+                data["Net Worth Amount"] = formatted_net_worth if formatted_net_worth != "" else "0"
+                data["Net Worth Currency"] = "USD"
+            except (ValueError, ArithmeticError):
+                pass
 
         extracted_data.append(Transaction.model_validate(data))
 

--- a/models.py
+++ b/models.py
@@ -47,6 +47,7 @@ class RawTokenTransfer(BaseModel):
     total: Total
     token: Token
     tokenDecimal: str
+    contractAddress: str
 
 
 class RawNFTTransfer(BaseModel):

--- a/price_service.py
+++ b/price_service.py
@@ -1,0 +1,136 @@
+import logging
+import os
+import time
+from datetime import datetime
+from typing import Dict, Optional, Union
+from decimal import Decimal
+
+from config import COINGECKO_BASE_URL, COINGECKO_PLATFORM_MAP, TIMEOUT, NATIVE_CURRENCIES
+from fetch_blockchain_data import session
+
+# Cache for token prices to avoid redundant API calls and respect rate limits
+# Key format: "platform:contract_address:timestamp_day" for tokens
+# Key format: "coin_id:timestamp_day" for native coins
+_price_cache: Dict[str, Optional[Decimal]] = {}
+
+def get_token_price(
+    chain: str,
+    timestamp: int,
+    contract_address: Optional[str] = None,
+    symbol: Optional[str] = None
+) -> Optional[Decimal]:
+    """
+    Fetches the historical price of a token or native coin from Coingecko.
+
+    Args:
+        chain: The blockchain name (e.g., 'ethereum', 'polygon', 'mintchain').
+        timestamp: Unix timestamp of the transaction.
+        contract_address: The contract address of the token (None for native currency).
+        symbol: The symbol of the token (used for native currency lookup).
+
+    Returns:
+        The price in USD as a Decimal, or None if not found.
+    """
+    # Convert timestamp to YYYY-MM-DD for Coingecko's historical API
+    date_str = datetime.fromtimestamp(timestamp).strftime("%d-%m-%Y")
+
+    platform_id = COINGECKO_PLATFORM_MAP.get(chain)
+
+    if contract_address:
+        # ERC-20 token price by contract address
+        if not platform_id:
+            logging.warning(f"No Coingecko platform ID found for chain: {chain}")
+            return None
+
+        cache_key = f"{platform_id}:{contract_address.lower()}:{date_str}"
+        if cache_key in _price_cache:
+            return _price_cache[cache_key]
+
+        price = _fetch_price_by_contract(platform_id, contract_address, date_str)
+        _price_cache[cache_key] = price
+        return price
+    else:
+        # Native currency price
+        lookup_symbol = symbol.upper() if symbol else NATIVE_CURRENCIES.get(chain, "ETH").upper()
+        coin_id = _get_coin_id_by_symbol(lookup_symbol)
+
+        if not coin_id:
+            logging.warning(f"No Coingecko coin ID found for symbol: {lookup_symbol}")
+            return None
+
+        cache_key = f"{coin_id}:{date_str}"
+        if cache_key in _price_cache:
+            return _price_cache[cache_key]
+
+        price = _fetch_price_by_coin_id(coin_id, date_str)
+        _price_cache[cache_key] = price
+        return price
+
+def _get_coin_id_by_symbol(symbol: str) -> Optional[str]:
+    """Maps a native currency symbol to a Coingecko coin ID."""
+    mapping = {
+        "ETH": "ethereum",
+        "MATIC": "matic-network",
+        "BNB": "binancecoin",
+        "ARB": "arbitrum",
+        "OP": "optimism",
+    }
+    return mapping.get(symbol.upper())
+
+def _fetch_price_by_contract(platform_id: str, contract_address: str, date_str: str) -> Optional[Decimal]:
+    """Fetches historical price using Coingecko's /coins/{id}/contract/{contract_address}/history endpoint."""
+    # Note: Coingecko's public API for historical contract price is a bit tricky.
+    # Usually, we first need to find the coin ID by contract address.
+    coin_id = _get_coin_id_from_contract(platform_id, contract_address)
+    if not coin_id:
+        return None
+    return _fetch_price_by_coin_id(coin_id, date_str)
+
+def _get_coin_id_from_contract(platform_id: str, contract_address: str) -> Optional[str]:
+    """Finds the Coingecko coin ID for a given contract address on a platform."""
+    url = f"{COINGECKO_BASE_URL}/coins/{platform_id}/contract/{contract_address.lower()}"
+    api_key = os.getenv("COINGECKO_API_KEY")
+    headers = {"x-cg-demo-api-key": api_key} if api_key else {}
+
+    try:
+        response = session.get(url, headers=headers, timeout=TIMEOUT)
+        if response.status_code == 429:
+            logging.warning("Coingecko rate limit exceeded. Sleeping for 30 seconds.")
+            time.sleep(30)
+            return _get_coin_id_from_contract(platform_id, contract_address)
+
+        response.raise_for_status()
+        data = response.json()
+        return data.get("id")
+    except Exception as e:
+        logging.error(f"Error fetching coin ID for {contract_address} on {platform_id}: {e}")
+        return None
+
+def _fetch_price_by_coin_id(coin_id: str, date_str: str) -> Optional[Decimal]:
+    """Fetches historical price using Coingecko's /coins/{id}/history endpoint."""
+    url = f"{COINGECKO_BASE_URL}/coins/{coin_id}/history"
+    params = {"date": date_str, "localization": "false"}
+    api_key = os.getenv("COINGECKO_API_KEY")
+    headers = {"x-cg-demo-api-key": api_key} if api_key else {}
+
+    try:
+        response = session.get(url, params=params, headers=headers, timeout=TIMEOUT)
+        if response.status_code == 429:
+            logging.warning("Coingecko rate limit exceeded. Sleeping for 30 seconds.")
+            time.sleep(30)
+            return _fetch_price_by_coin_id(coin_id, date_str)
+
+        response.raise_for_status()
+        data = response.json()
+
+        market_data = data.get("market_data")
+        if market_data:
+            current_price = market_data.get("current_price")
+            if current_price:
+                usd_price = current_price.get("usd")
+                if usd_price is not None:
+                    return Decimal(str(usd_price))
+        return None
+    except Exception as e:
+        logging.error(f"Error fetching price for {coin_id} on {date_str}: {e}")
+        return None

--- a/tests/test_extract_transaction_data.py
+++ b/tests/test_extract_transaction_data.py
@@ -1,9 +1,13 @@
+from decimal import Decimal
+from unittest.mock import patch
 from models import Raw1155Transfer, RawNFTTransfer, RawTokenTransfer, RawTransaction, Transaction, Address, Token, Total
 from extract_transaction_data import extract_transaction_data
 
 WALLET_ADDRESS = "0x1234567890123456789012345678901234567890"
 
-def test_extract_transaction_data_regular_transaction_sent():
+@patch("extract_transaction_data.get_token_price")
+def test_extract_transaction_data_regular_transaction_sent(mock_get_price):
+    mock_get_price.return_value = Decimal("2000.0")
     raw_trx_data = {
         "hash": "0xabc",
         "from": {"hash": WALLET_ADDRESS},
@@ -25,7 +29,9 @@ def test_extract_transaction_data_regular_transaction_sent():
     assert trx.fee_currency == "ETH"
     assert trx.received_amount is None
 
-def test_extract_transaction_data_regular_transaction_received():
+@patch("extract_transaction_data.get_token_price")
+def test_extract_transaction_data_regular_transaction_received(mock_get_price):
+    mock_get_price.return_value = Decimal("2000.0")
     raw_trx_data = {
         "hash": "0xabc",
         "from": {"hash": "0x456"},
@@ -43,8 +49,12 @@ def test_extract_transaction_data_regular_transaction_received():
     assert trx.received_currency == "ETH"
     assert trx.sent_amount is None
     assert trx.fee_amount is None
+    assert trx.net_worth_amount == "5000"
+    assert trx.net_worth_currency == "USD"
 
-def test_extract_nft_transfer_data():
+@patch("extract_transaction_data.get_token_price")
+def test_extract_nft_transfer_data(mock_get_price):
+    mock_get_price.return_value = None
     raw_data = [
         RawNFTTransfer.model_validate({
             'hash': '0xnft',
@@ -62,7 +72,9 @@ def test_extract_nft_transfer_data():
     assert extracted[0].sent_currency == 'NFT'
     assert extracted[0].description == 'nft_transfer'
 
-def test_extract_1155_transfer_data():
+@patch("extract_transaction_data.get_token_price")
+def test_extract_1155_transfer_data(mock_get_price):
+    mock_get_price.return_value = Decimal("10.0")
     raw_data = [
         Raw1155Transfer.model_validate({
             'hash': '0x1155',
@@ -81,7 +93,9 @@ def test_extract_1155_transfer_data():
     assert extracted[0].received_currency == '1155'
     assert extracted[0].description == '1155_transfer'
 
-def test_extract_transaction_data_polygon_native():
+@patch("extract_transaction_data.get_token_price")
+def test_extract_transaction_data_polygon_native(mock_get_price,):
+    mock_get_price.return_value = Decimal("0.8")
     raw_trx_data = {
         "hash": "0xpoly",
         "from": {"hash": WALLET_ADDRESS},
@@ -98,7 +112,9 @@ def test_extract_transaction_data_polygon_native():
     assert trx.sent_currency == "MATIC"
     assert trx.fee_currency == "MATIC"
 
-def test_extract_transaction_data_fee_precision():
+@patch("extract_transaction_data.get_token_price")
+def test_extract_transaction_data_fee_precision(mock_get_price):
+    mock_get_price.return_value = Decimal("2000.0")
     # Test case with very small gas price to check for precision issues
     raw_trx_data = {
         "hash": "0xabc",
@@ -122,7 +138,9 @@ def test_extract_transaction_data_fee_precision():
     # 617,283,945,000,000 / 1e18 = 0.000617283945
     assert transactions[0].fee_amount == "0.000617283945"
 
-def test_extract_transaction_data_token_transfer_sent():
+@patch("extract_transaction_data.get_token_price")
+def test_extract_transaction_data_token_transfer_sent(mock_get_price):
+    mock_get_price.return_value = Decimal("1.0")
     raw_token_trx_data = {
         "hash": "0xdef",
         "from": {"hash": WALLET_ADDRESS},
@@ -130,7 +148,8 @@ def test_extract_transaction_data_token_transfer_sent():
         "timeStamp": "1672531201",
         "total": {"value": "2000000"},
         "token": {"symbol": "USDC"},
-        "tokenDecimal": "6"
+        "tokenDecimal": "6",
+        "contractAddress": "0xusdc"
     }
     raw_token_trx = RawTokenTransfer.model_validate(raw_token_trx_data)
     transactions = extract_transaction_data([raw_token_trx], "token_transfers", WALLET_ADDRESS, "mintchain")
@@ -140,8 +159,12 @@ def test_extract_transaction_data_token_transfer_sent():
     assert trx.sent_currency == "USDC"
     assert trx.received_amount is None
     assert trx.fee_amount is None
+    assert trx.net_worth_amount == "2"
+    assert trx.net_worth_currency == "USD"
 
-def test_extract_transaction_data_token_transfer_received():
+@patch("extract_transaction_data.get_token_price")
+def test_extract_transaction_data_token_transfer_received(mock_get_price):
+    mock_get_price.return_value = Decimal("0.5")
     raw_token_trx_data = {
         "hash": "0xdef",
         "from": {"hash": "0x456"},
@@ -149,7 +172,8 @@ def test_extract_transaction_data_token_transfer_received():
         "timeStamp": "1672531201",
         "total": {"value": "500000000000000000000"}, # 500 TKN
         "token": {"symbol": "TKN"},
-        "tokenDecimal": "18"
+        "tokenDecimal": "18",
+        "contractAddress": "0xtkn"
     }
     raw_token_trx = RawTokenTransfer.model_validate(raw_token_trx_data)
     transactions = extract_transaction_data([raw_token_trx], "token_transfers", WALLET_ADDRESS, "mintchain")
@@ -160,7 +184,9 @@ def test_extract_transaction_data_token_transfer_received():
     assert trx.sent_amount is None
     assert trx.fee_amount is None
 
-def test_extract_transaction_data_internal_transaction_sent():
+@patch("extract_transaction_data.get_token_price")
+def test_extract_transaction_data_internal_transaction_sent(mock_get_price):
+    mock_get_price.return_value = Decimal("2000.0")
     # Internal transactions from Etherscan usually don't have gasPrice
     raw_trx_data = {
         "hash": "0xghi",
@@ -183,7 +209,9 @@ def test_extract_transaction_data_internal_transaction_sent():
     assert trx.fee_amount is None # Fee is None because gasPrice is missing
     assert trx.received_amount is None
 
-def test_extract_transaction_data_internal_transaction_received():
+@patch("extract_transaction_data.get_token_price")
+def test_extract_transaction_data_internal_transaction_received(mock_get_price):
+    mock_get_price.return_value = Decimal("2000.0")
     raw_trx_data = {
         "hash": "0xghi",
         "from": {"hash": "0x456"},

--- a/tests/test_extraction.py
+++ b/tests/test_extraction.py
@@ -22,6 +22,7 @@ MOCK_TOKEN_TRANSFER = RawTokenTransfer.model_validate({
     "from": {"hash": "sender"},
     "to": {"hash": WALLET_ADDRESS},
     "tokenDecimal": "18",
+    "contractAddress": "0xtok",
 })
 
 def test_extract_transaction_data_sent():

--- a/tests/test_fetch_blockchain_data.py
+++ b/tests/test_fetch_blockchain_data.py
@@ -113,6 +113,7 @@ def test_adapter_get_token_transfers_success(mocked_responses):
                     "total": {"value": "200"},
                     "token": {"symbol": "TKN"},
                     "tokenDecimal": "18",
+                    "contractAddress": "0xtkn",
                 }
             ]
         },
@@ -440,6 +441,7 @@ MOCK_TOKEN_TRANSFERS_RESPONSE = {
             "total": {"value": "500"},
             "token": {"symbol": "TKN"},
             "tokenDecimal": "18",
+            "contractAddress": "0xtkn1",
         },
         {
             "hash": "0xtokenhash2",
@@ -449,6 +451,7 @@ MOCK_TOKEN_TRANSFERS_RESPONSE = {
             "total": {"value": "1000"},
             "token": {"symbol": "MTK"},
             "tokenDecimal": "6",
+            "contractAddress": "0xmtk2",
         },
     ],
 }

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -46,6 +46,7 @@ def mock_adapter():
                     "to": {"hash": "test_wallet"},
                     "hash": "0x2",
                     "tokenDecimal": "18",
+                        "contractAddress": "0x2",
                 }
             )
         ]

--- a/tests/test_price_service.py
+++ b/tests/test_price_service.py
@@ -1,0 +1,119 @@
+import pytest
+import responses
+from decimal import Decimal
+from unittest.mock import patch
+from price_service import get_token_price, _price_cache
+
+@pytest.fixture
+def mocked_responses():
+    with responses.RequestsMock() as rsps:
+        yield rsps
+
+def test_get_native_token_price(mocked_responses):
+    _price_cache.clear()
+    chain = "ethereum"
+    timestamp = 1672531200  # 2023-01-01
+    date_str = "01-01-2023"
+    coin_id = "ethereum"
+
+    url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/history?date={date_str}&localization=false"
+    mocked_responses.add(
+        responses.GET,
+        url,
+        json={
+            "market_data": {
+                "current_price": {"usd": 1200.50}
+            }
+        },
+        status=200
+    )
+
+    price = get_token_price(chain, timestamp)
+    assert price == Decimal("1200.5")
+    assert len(mocked_responses.calls) == 1
+
+    # Test caching
+    price_cached = get_token_price(chain, timestamp)
+    assert price_cached == Decimal("1200.5")
+    assert len(mocked_responses.calls) == 1
+
+def test_get_erc20_token_price(mocked_responses):
+    _price_cache.clear()
+    chain = "polygon"
+    platform_id = "polygon-pos"
+    contract_address = "0x2791bca1f2de4661ed88a30c99a7a9449aa84174" # USDC on Polygon
+    timestamp = 1672531200
+    date_str = "01-01-2023"
+    coin_id = "usd-coin"
+
+    # Mock coin ID lookup
+    mocked_responses.add(
+        responses.GET,
+        f"https://api.coingecko.com/api/v3/coins/{platform_id}/contract/{contract_address}",
+        json={"id": coin_id},
+        status=200
+    )
+
+    # Mock price lookup
+    mocked_responses.add(
+        responses.GET,
+        f"https://api.coingecko.com/api/v3/coins/{coin_id}/history?date={date_str}&localization=false",
+        json={
+            "market_data": {
+                "current_price": {"usd": 1.0}
+            }
+        },
+        status=200
+    )
+
+    price = get_token_price(chain, timestamp, contract_address=contract_address)
+    assert price == Decimal("1.0")
+    assert len(mocked_responses.calls) == 2
+
+@patch("time.sleep", return_value=None)
+def test_rate_limiting(mock_sleep, mocked_responses):
+    _price_cache.clear()
+    chain = "ethereum"
+    timestamp = 1672531200
+    date_str = "01-01-2023"
+    coin_id = "ethereum"
+    url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/history?date={date_str}&localization=false"
+
+    # Add a 429 response followed by a 200 response
+    mocked_responses.add(responses.GET, url, status=429)
+    mocked_responses.add(
+        responses.GET,
+        url,
+        json={"market_data": {"current_price": {"usd": 1200.50}}},
+        status=200
+    )
+
+    price = get_token_price(chain, timestamp)
+    assert price == Decimal("1200.5")
+    assert len(mocked_responses.calls) == 2
+    assert mock_sleep.call_count == 1
+
+def test_cache_none_result(mocked_responses):
+    _price_cache.clear()
+    chain = "ethereum"
+    timestamp = 1672531200
+    date_str = "01-01-2023"
+    coin_id = "ethereum"
+    url = f"https://api.coingecko.com/api/v3/coins/{coin_id}/history?date={date_str}&localization=false"
+
+    # Mock a response that doesn't contain price data
+    mocked_responses.add(
+        responses.GET,
+        url,
+        json={"market_data": {}},
+        status=200
+    )
+
+    price = get_token_price(chain, timestamp)
+    assert price is None
+    assert len(mocked_responses.calls) == 1
+
+    # Second call should use cache (return None without another API call)
+    price_cached = get_token_price(chain, timestamp)
+    assert price_cached is None
+    assert len(mocked_responses.calls) == 1

--- a/tests/test_transaction_categorization.py
+++ b/tests/test_transaction_categorization.py
@@ -25,6 +25,7 @@ def create_mock_raw_token_transfer(to_address: str, token_decimal: str) -> RawTo
         "total": {"value": "100"},
         "token": {"symbol": "TKN"},
         "tokenDecimal": token_decimal,
+            "contractAddress": "0xtkn",
     })
 
 # Test cases

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -36,7 +36,8 @@ def test_raw_token_transfer_model():
         "to": {"hash": "0xto"},
         "total": {"value": "500"},
         "token": {"symbol": "TOK"},
-        "tokenDecimal": "18"
+            "tokenDecimal": "18",
+            "contractAddress": "0xtok"
     }
     trx = RawTokenTransfer.model_validate(data)
     assert trx.hash == "0xdef"


### PR DESCRIPTION
This change integrates a price mapping service that uses the Coingecko historical API to populate 'Net Worth Amount' and 'Net Worth Currency' columns in the exported CSVs. It includes a robust caching mechanism and rate-limit handling for both native and ERC-20 tokens across supported chains (MintChain, Ethereum, Polygon, Base, Arbitrum, Optimism).

Fixes #139

---
*PR created automatically by Jules for task [15879999463595309261](https://jules.google.com/task/15879999463595309261) started by @username-anthony-is-not-available*