### PR TITLE
Support for MintChain Internal Transactions and Routescan V2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A tool designed to streamline the process of exporting blockchain transaction da
 
 ## Features
 
-- Fetches transactions, token transfers, and internal transactions from multiple blockchain explorer APIs.
-- Supports multiple blockchains: Etherscan (Ethereum), Basescan (Base), Arbiscan (Arbitrum), and MintChain.
+- Fetches transactions, token transfers, and internal transactions (including MintChain contract calls) from multiple blockchain explorer APIs.
+- Supports multiple blockchains: Etherscan (Ethereum), Basescan (Base), Arbiscan (Arbitrum), and MintChain (with full support for Routescan V2 internal traces).
 - Combines and sorts all transaction data by timestamp.
 - Exports the transaction data to multiple formats: generic CSV, JSON, Koinly, CoinTracker, and CryptoTaxCalculator.
 - Filters transactions by date range.

--- a/explorer_adapters.py
+++ b/explorer_adapters.py
@@ -201,6 +201,7 @@ class ArbiscanAdapter(EtherscanAdapter):
 
 
 class MintchainAdapter(EtherscanAdapter):
+    """Adapter for MintChain explorer using Routescan V2 API."""
     pass
 
 

--- a/fetch_blockchain_data.py
+++ b/fetch_blockchain_data.py
@@ -72,7 +72,9 @@ def fetch_data(endpoint: str, model: Type[T]) -> List[T]:
         if status == "0" and message == "No transactions found":
             return []
 
-        # Check for data in 'result' (Etherscan) or 'items' (Routescan V2)
+        # Check for data in 'result' (standard Etherscan) or 'items' (Routescan V2/Blockscout).
+        # Routescan V2 APIs, used by chains like MintChain, return the transaction list
+        # in an 'items' key instead of the Etherscan-standard 'result' key.
         if "result" in data:
             result_list = data.get("result")
         elif "items" in data:

--- a/fetch_blockchain_data.py
+++ b/fetch_blockchain_data.py
@@ -72,12 +72,18 @@ def fetch_data(endpoint: str, model: Type[T]) -> List[T]:
         if status == "0" and message == "No transactions found":
             return []
 
-        result_list = data.get("result")
+        # Check for data in 'result' (Etherscan) or 'items' (Routescan V2)
+        if "result" in data:
+            result_list = data.get("result")
+        elif "items" in data:
+            result_list = data.get("items")
+        else:
+            result_list = None
 
         # Handle malformed result formats
         if not isinstance(result_list, list):
             logging.error(
-                f"API response for {endpoint} does not contain a list in 'result': {data}"
+                f"API response for {endpoint} does not contain a list in 'result' or 'items': {data}"
             )
             return []
 

--- a/models.py
+++ b/models.py
@@ -1,5 +1,5 @@
-from typing import Optional
-from pydantic import BaseModel, Field
+from typing import Any, Optional
+from pydantic import BaseModel, Field, model_validator, AliasChoices
 from enum import Enum
 
 
@@ -20,6 +20,13 @@ class TransactionType(Enum):
 class Address(BaseModel):
     hash: str
 
+    @model_validator(mode="before")
+    @classmethod
+    def handle_raw_address(cls, data: Any) -> Any:
+        if isinstance(data, str):
+            return {"hash": data}
+        return data
+
 
 class Token(BaseModel):
     symbol: str
@@ -30,12 +37,12 @@ class Total(BaseModel):
 
 
 class RawTransaction(BaseModel):
-    hash: str
+    hash: str = Field(..., validation_alias=AliasChoices("hash", "transactionHash"))
     timeStamp: str
     from_address: Address = Field(..., alias="from")
     to_address: Address = Field(..., alias="to")
     value: str
-    gasUsed: str
+    gasUsed: str = Field(..., validation_alias=AliasChoices("gasUsed", "gas"))
     gasPrice: Optional[str] = None
 
 

--- a/tests/test_mintchain_internal.py
+++ b/tests/test_mintchain_internal.py
@@ -1,0 +1,70 @@
+import responses
+import logging
+from explorer_adapters import MintchainAdapter
+from models import RawTransaction
+
+WALLET_ADDRESS = "0xe55b0367a178d9cf5f03354fd06904a8b3bb682a"
+CHAIN = "mintchain"
+
+@responses.activate
+def test_mintchain_internal_transactions_with_items_and_raw_addresses():
+    adapter = MintchainAdapter(CHAIN)
+    base_url = "https://api.routescan.io/v2/network/mainnet/evm/185/etherscan"
+    mock_url = f"{base_url}?module=account&action=txlistinternal&address={WALLET_ADDRESS}&startblock=0&endblock=99999999&sort=asc&page=1&offset=10000"
+
+    # Mocking the Routescan V2 response structure
+    mock_response = {
+        "status": "1",
+        "message": "OK",
+        "result": [
+            {
+                "hash": "0xd49029e9e815284a1395d834924df6c2ed457a8b9689ab5a35ddb422ac4eb076",
+                "timeStamp": "1718770339",
+                "from": "0xe55b0367a178d9cf5f03354fd06904a8b3bb682a",
+                "to": "0x4200000000000000000000000000000000000006",
+                "value": "1000000000000000",
+                "gas": "36762"
+            }
+        ]
+    }
+
+    responses.add(responses.GET, mock_url, json=mock_response, status=200)
+
+    internal_txs = adapter.get_internal_transactions(WALLET_ADDRESS)
+
+    assert len(internal_txs) == 1
+    assert internal_txs[0].hash == "0xd49029e9e815284a1395d834924df6c2ed457a8b9689ab5a35ddb422ac4eb076"
+    assert internal_txs[0].from_address.hash == "0xe55b0367a178d9cf5f03354fd06904a8b3bb682a"
+    assert internal_txs[0].to_address.hash == "0x4200000000000000000000000000000000000006"
+    assert internal_txs[0].gasUsed == "36762"
+
+@responses.activate
+def test_mintchain_internal_transactions_with_items_key():
+    adapter = MintchainAdapter(CHAIN)
+    base_url = "https://api.routescan.io/v2/network/mainnet/evm/185/etherscan"
+    mock_url = f"{base_url}?module=account&action=txlistinternal&address={WALLET_ADDRESS}&startblock=0&endblock=99999999&sort=asc&page=1&offset=10000"
+
+    # Mocking the Routescan V2 response structure with 'items' instead of 'result'
+    mock_response = {
+        "status": "1",
+        "message": "OK",
+        "items": [
+            {
+                "hash": "0xd49029e9e815284a1395d834924df6c2ed457a8b9689ab5a35ddb422ac4eb076",
+                "timeStamp": "1718770339",
+                "from": "0xe55b0367a178d9cf5f03354fd06904a8b3bb682a",
+                "to": "0x4200000000000000000000000000000000000006",
+                "value": "1000000000000000",
+                "gas": "36762"
+            }
+        ]
+    }
+
+    responses.add(responses.GET, mock_url, json=mock_response, status=200)
+
+    internal_txs = adapter.get_internal_transactions(WALLET_ADDRESS)
+
+    assert len(internal_txs) == 1
+    assert internal_txs[0].hash == "0xd49029e9e815284a1395d834924df6c2ed457a8b9689ab5a35ddb422ac4eb076"
+    assert internal_txs[0].from_address.hash == "0xe55b0367a178d9cf5f03354fd06904a8b3bb682a"
+    assert internal_txs[0].gasUsed == "36762"

--- a/tests/test_mintchain_internal.py
+++ b/tests/test_mintchain_internal.py
@@ -1,13 +1,11 @@
 import responses
-import logging
 from explorer_adapters import MintchainAdapter
-from models import RawTransaction
 
 WALLET_ADDRESS = "0xe55b0367a178d9cf5f03354fd06904a8b3bb682a"
 CHAIN = "mintchain"
 
 @responses.activate
-def test_mintchain_internal_transactions_with_items_and_raw_addresses():
+def test_mintchain_internal_transactions_with_result_key_and_raw_addresses():
     adapter = MintchainAdapter(CHAIN)
     base_url = "https://api.routescan.io/v2/network/mainnet/evm/185/etherscan"
     mock_url = f"{base_url}?module=account&action=txlistinternal&address={WALLET_ADDRESS}&startblock=0&endblock=99999999&sort=asc&page=1&offset=10000"


### PR DESCRIPTION
This PR adds support for MintChain internal transactions by enhancing the core fetching and modeling logic to accommodate variations in the Routescan V2 API. 

Key changes:
- **Flexible Address Parsing:** Added a `model_validator` to the `Address` class in `models.py` to handle addresses provided as raw strings, which is common in some internal transaction responses.
- **Enhanced Data Fetching:** Updated `fetch_data` in `fetch_blockchain_data.py` to check for transaction data in both the traditional `result` key (Etherscan) and the `items` key (Routescan V2). The logic now robustly handles empty lists in either key.
- **Model Aliases:** Added `AliasChoices` for `RawTransaction` fields to support `transactionHash` and `gas` (as used in some internal transaction responses).
- **Regression Testing:** Introduced `tests/test_mintchain_internal.py` to verify these changes against real-world Routescan V2 response structures.

All existing and new tests pass.

Fixes #138

---
*PR created automatically by Jules for task [15041480040699005714](https://jules.google.com/task/15041480040699005714) started by @username-anthony-is-not-available*